### PR TITLE
feat(core): add A2A messaging support to BaseAgent\n\nImplemented asy…

### DIFF
--- a/src/video_pipeline/core/base_agent.py
+++ b/src/video_pipeline/core/base_agent.py
@@ -13,7 +13,8 @@ If you need reusable utilities shared across agents (e.g. retry logic, API helpe
 from __future__ import annotations
 
 import logging
-from typing import Any, Dict, Optional
+import asyncio
+from typing import Any, Dict, Optional, Callable, Awaitable, Iterable
 
 try:
     from adk import Agent  # type: ignore
@@ -29,6 +30,35 @@ except ImportError:  # pragma: no cover
         def __init__(self, name: str, **kwargs: Any) -> None:  # noqa: D401
             self.name = name
 
+# ---------------------------------------------------------------------------
+# Optional A2A protocol client import with graceful fallback
+# ---------------------------------------------------------------------------
+
+try:
+    # The real Google A2A Python SDK exposes `Client` (per upstream examples).
+    from a2a import Client as _A2AClient  # type: ignore
+
+    _A2A_AVAILABLE = True
+except Exception:  # pragma: no cover – A2A SDK might not be installed yet
+    _A2A_AVAILABLE = False
+
+    class _A2AClient:  # type: ignore
+        """Minimal no-op stub so the codebase can run without A2A installed."""
+
+        def __init__(self, *args: Any, **kwargs: Any) -> None:  # noqa: D401
+            pass
+
+        async def send_event(self, event: Dict[str, Any]) -> None:  # noqa: D401
+            return None
+
+        async def send_request(self, to_agent: str, message: Dict[str, Any]) -> Any:  # noqa: D401,E501
+            return None
+
+        def register_handler(
+            self, message_type: str, handler: Callable[[Any], Awaitable[None]]
+        ) -> None:  # noqa: D401
+            return None
+
 
 class BaseAgent(Agent):
     """Abstract base class wrapping :class:`adk.Agent` with extras.
@@ -38,10 +68,38 @@ class BaseAgent(Agent):
     """
 
     def __init__(self, name: str, **kwargs: Any) -> None:  # noqa: D401
-        # Pass through to ADK base class (or shim)
+        """Create a new agent.
+
+        Parameters
+        ----------
+        name
+            Human-readable identifier.
+        a2a_client
+            Optional pre-configured A2A client instance.  If *None*, the
+            constructor attempts to create a default ``_A2AClient`` so that
+            messaging APIs always exist (even if they are no-op stubs while the
+            real SDK is missing).
+        **kwargs
+            Passed straight through to the underlying ADK ``Agent``.
+        """
+
+        # Extract optional A2A client so we don't forward an unexpected kwarg to
+        # the ADK Agent base class.
+        a2a_client: Optional[_A2AClient] = kwargs.pop("a2a_client", None)  # type: ignore[arg-type]
+
+        # Initialise ADK parent (or shim) *before* we access logging so ADK can
+        # override attrs if necessary.
         super().__init__(name=name, **kwargs)
-        # Standard logger per agent
+
+        # Standard logger per agent (namespaced by agent name)
         self.logger = logging.getLogger(name)
+
+        # ------------------------------------------------------------------
+        # A2A wiring
+        # ------------------------------------------------------------------
+        self._a2a: _A2AClient = a2a_client or _A2AClient()
+        # Local registry for convenience – mirrors remote registration too.
+        self._handlers: Dict[str, Callable[[Any], Awaitable[None]]] = {}
 
     # ---------------------------------------------------------------------
     # Public API expected by the WorkflowManager
@@ -76,3 +134,57 @@ class BaseAgent(Agent):
         raise NotImplementedError(
             "_execute must be implemented by concrete agent subclasses"
         )
+
+    # ------------------------------------------------------------------
+    # 🔌 A2A Messaging Helpers
+    # ------------------------------------------------------------------
+
+    async def broadcast_event(self, event_data: Dict[str, Any]) -> None:  # noqa: D401,E501
+        """Publish an *event* to **all** interested agents via A2A.
+
+        The underlying A2A client is awaited, so callers inside synchronous
+        code paths should schedule this with :pyfunc:`asyncio.create_task` or
+        wrap the coroutine with :pyfunc:`asyncio.run` where appropriate.
+        """
+
+        await self._a2a.send_event(event_data)
+
+    async def send_request(self, to_agent: str, message: Dict[str, Any]) -> Any:  # noqa: D401,E501
+        """Send a direct *request* to another agent.
+
+        Returns
+        -------
+        Any
+            Whatever the remote agent responds with (depends on protocol).
+        """
+
+        return await self._a2a.send_request(to_agent, message)
+
+    def register_handler(
+        self,
+        message_type: str,
+        handler_func: Callable[[Any], Awaitable[None]],
+    ) -> None:  # noqa: D401,E501
+        """Register a coroutine callback for a specific *message_type*."""
+
+        self._handlers[message_type] = handler_func
+        # Propagate to underlying client (no-op if stub).
+        self._a2a.register_handler(message_type, handler_func)
+
+    async def stream_updates(self, generator: Iterable[Any]) -> None:  # noqa: D401,E501
+        """Utility that relays progress *updates* emitted by *generator*.
+
+        Parameters
+        ----------
+        generator
+            Any synchronous or asynchronous iterable yielding update payloads.
+        """
+
+        # Support both sync and async iterables.
+        if hasattr(generator, "__aiter__"):
+            async for update in generator:  # type: ignore[misc]
+                await self.broadcast_event(update)
+        else:
+            for update in generator:  # type: ignore[not-an-iterable]
+                # Fire-and-forget to avoid blocking sync caller.
+                asyncio.create_task(self.broadcast_event(update))


### PR DESCRIPTION
This pull request enhances the `BaseAgent` class in the `video_pipeline` core by introducing robust support for A2A (agent-to-agent) messaging, while ensuring graceful degradation if the A2A SDK is not installed. It adds convenient async messaging helpers, improves dependency handling, and extends the agent API for easier integration with distributed workflows.

**A2A protocol integration and messaging helpers:**

* Added optional import and graceful fallback for the Google A2A SDK: if the SDK is missing, a no-op stub is used so the codebase remains runnable and messaging APIs are always present.
* Extended the `BaseAgent` constructor to accept an optional `a2a_client` parameter and to initialize A2A messaging attributes, enabling agents to send and receive messages even if the SDK is not installed.

**New async messaging API:**

* Added `broadcast_event`, `send_request`, and `register_handler` methods to `BaseAgent` for sending events, sending direct requests, and registering message handlers using the A2A protocol (or stub).
* Added `stream_updates` utility to relay progress updates from synchronous or asynchronous generators as A2A events, supporting both sync and async workflows.

**Type and import improvements:**

* Updated imports and type annotations to support async messaging and handler registration, including `Callable`, `Awaitable`, and `Iterable`.…nc A2A helpers (broadcast_event, send_request, register_handler, stream_updates) with graceful stub fallback when A2A SDK is absent; added optional client wiring in __init__.